### PR TITLE
Update Vkontakte.php

### DIFF
--- a/src/Providers/Vkontakte.php
+++ b/src/Providers/Vkontakte.php
@@ -17,7 +17,7 @@ class Vkontakte extends AbstractProvider
     
     public function getUrl()
     {
-        $url = 'http://vk.com/share.php?'
+        $url = 'https://vk.com/share.php?'
              . 'url=' . urlencode($this->getOption('url', Request::url()));
         
         $title = $this->getOption('title');


### PR DESCRIPTION
According to https://vk.com/dev/widget_share share url should be using HTTPS protocol and therefore usage of HTTP no longer guarantees parse of meta-tags from a shared page.