### PR TITLE
moved default url to constructor method

### DIFF
--- a/src/Providers/AbstractProvider.php
+++ b/src/Providers/AbstractProvider.php
@@ -25,6 +25,8 @@ abstract class AbstractProvider
                 'timeout' => config('yaro.soc-share.http_timeout')
             ) 
         ));
+
+        $this->options['url'] = $this->options['url'] ? : Request::url();
     } // end __construct
 
     protected function getOption($ident, $default = false)

--- a/src/Providers/Facebook.php
+++ b/src/Providers/Facebook.php
@@ -25,7 +25,7 @@ class Facebook extends AbstractProvider
         $url = 'https://www.facebook.com/dialog/share?'
              . 'app_id=' . $this->getRequiredOption('app_id') .'&'
              . 'display=' . $this->getOption('display', 'popup') .'&'
-             . 'href=' . urlencode($this->getOption('url', Request::url())) .'&'
+             . 'href=' . urlencode($this->getOption('url')) .'&'
              . 'redirect_uri=' . urlencode($this->getOption('redirect_uri', URL::to('_soc-share/close/window')));
              
         $from = $this->getOption('from');
@@ -83,7 +83,7 @@ class Facebook extends AbstractProvider
     
     public function getSimpleShareUrl()
     {
-        return 'https://www.facebook.com/share.php?u=' . urlencode($this->getOption('url', Request::url()));
+        return 'https://www.facebook.com/share.php?u=' . urlencode($this->getOption('url'));
     } // end getSimpleShareUrl
     
     public function getCount()
@@ -93,7 +93,7 @@ class Facebook extends AbstractProvider
             return $count;
         }
         
-        $url = 'http://graph.facebook.com/?id=' . urlencode($this->getOption('url', Request::url()));
+        $url = 'http://graph.facebook.com/?id=' . urlencode($this->getOption('url'));
              
         $result = $this->fileGetContents($url);
         $result = json_decode($result, true);

--- a/src/Providers/GooglePlus.php
+++ b/src/Providers/GooglePlus.php
@@ -18,7 +18,7 @@ class GooglePlus extends AbstractProvider
     public function getUrl()
     {
         $url = 'https://plus.google.com/share?'
-             . 'url=' . urlencode($this->getOption('url', Request::url()));
+             . 'url=' . urlencode($this->getOption('url'));
              
         $language = $this->getOption('hl');
         if ($language) {
@@ -36,7 +36,7 @@ class GooglePlus extends AbstractProvider
         }
         
         $url = 'https://plusone.google.com/_/+1/fastbutton?url='
-             . urlencode($this->getOption('url', Request::url())) 
+             . urlencode($this->getOption('url'))
              .'&count=true';
              
         $result = $this->fileGetContents($url);

--- a/src/Providers/Linkedin.php
+++ b/src/Providers/Linkedin.php
@@ -18,7 +18,7 @@ class Linkedin extends AbstractProvider
     public function getUrl()
     {
         $url = 'https://www.linkedin.com/shareArticle?mini=true'
-             . '&url=' . urlencode($this->getOption('url', Request::url()))
+             . '&url=' . urlencode($this->getOption('url'))
              . '&title=' . urlencode($this->getOption('title'))
              . '&summary=' . urlencode($this->getOption('summary'))
              . '&source=' . urlencode($this->getOption('source'));
@@ -34,7 +34,7 @@ class Linkedin extends AbstractProvider
         }
         
         $url = 'http://www.linkedin.com/countserv/count/share?format=json&url='
-             . urlencode($this->getOption('url', Request::url()));
+             . urlencode($this->getOption('url'));
         
         $result = $this->fileGetContents($url);
         $result = json_decode($result, true);

--- a/src/Providers/Odnoklassniki.php
+++ b/src/Providers/Odnoklassniki.php
@@ -18,7 +18,7 @@ class Odnoklassniki extends AbstractProvider
     public function getUrl()
     {
         $url = 'https://connect.ok.ru/dk?st.cmd=WidgetSharePreview&st.shareUrl='
-             . urlencode($this->getOption('url', Request::url()));
+             . urlencode($this->getOption('url'));
              
         return $url;
     } // end getUrl
@@ -31,7 +31,7 @@ class Odnoklassniki extends AbstractProvider
         }
         
         $url = 'https://connect.ok.ru/dk?st.cmd=extLike&uid=hai&ref='
-             . urlencode($this->getOption('url', Request::url()));
+             . urlencode($this->getOption('url'));
         
         $result = $this->fileGetContents($url);
         preg_match("~^ODKL\.updateCount\('hai','(\d+)'\);~", $result, $matches);

--- a/src/Providers/Pinterest.php
+++ b/src/Providers/Pinterest.php
@@ -17,7 +17,7 @@ class Pinterest extends AbstractProvider
     
     public function getUrl()
     {
-        $currentUrl = $this->getOption('url', Request::url());
+        $currentUrl = $this->getOption('url');
         $description = $this->getOption('description', Request::url());
         
         
@@ -39,7 +39,7 @@ class Pinterest extends AbstractProvider
         }
         
         $url = 'http://api.pinterest.com/v1/urls/count.json?callback=_&url=' 
-             . urlencode($this->getOption('url', Request::url()));
+             . urlencode($this->getOption('url'));
              
         $result = $this->fileGetContents($url);
         $result = trim($result, ')_(');

--- a/src/Providers/Tumblr.php
+++ b/src/Providers/Tumblr.php
@@ -18,7 +18,7 @@ class Tumblr extends AbstractProvider
     public function getUrl()
     {
         $url = 'https://www.tumblr.com/widgets/share/tool?canonicalUrl='
-             . urlencode($this->getOption('url', Request::url()))
+             . urlencode($this->getOption('url'))
              . '&title=' . urlencode($this->getOption('title'))
              . '&caption=' . urlencode($this->getOption('caption'));
           
@@ -38,7 +38,7 @@ class Tumblr extends AbstractProvider
         }
         
         $url = 'https://api.tumblr.com/v2/share/stats?url='
-             . urlencode($this->getOption('url', Request::url()));
+             . urlencode($this->getOption('url'));
         
         $result = $this->fileGetContents($url);
         

--- a/src/Providers/Twitter.php
+++ b/src/Providers/Twitter.php
@@ -17,7 +17,7 @@ class Twitter extends AbstractProvider
 
     public function getUrl()
     {
-        $currentUrl = $this->getOption('url', Request::url());
+        $currentUrl = $this->getOption('url');
         
         $url = 'https://twitter.com/share?'
              . 'url=' . urlencode($currentUrl);
@@ -55,7 +55,7 @@ class Twitter extends AbstractProvider
         }
         
         $url = 'https://cdn.api.twitter.com/1/urls/count.json?url=' 
-             . urlencode($this->getOption('url', Request::url()));
+             . urlencode($this->getOption('url'));
              
         $result = $this->fileGetContents($url);
         $result = json_decode($result, true);

--- a/src/Providers/Vkontakte.php
+++ b/src/Providers/Vkontakte.php
@@ -18,7 +18,7 @@ class Vkontakte extends AbstractProvider
     public function getUrl()
     {
         $url = 'https://vk.com/share.php?'
-             . 'url=' . urlencode($this->getOption('url', Request::url()));
+             . 'url=' . urlencode($this->getOption('url'));
         
         $title = $this->getOption('title');
         if ($title) {
@@ -49,7 +49,7 @@ class Vkontakte extends AbstractProvider
         }
         
         $url = 'https://vk.com/share.php?act=count&index=1&url=' 
-             . urlencode($this->getOption('url', Request::url()));
+             . urlencode($this->getOption('url'));
              
         $result = $this->fileGetContents($url);
         preg_match('~VK\.Share\.count\(\d+,\s*(\d+)\);~', $result, $matches);


### PR DESCRIPTION
There was an issue with getting share count from cache for multiple different URL.

When 'url' option was empty all pages shared the same cache tag therefore all of them had the same amount of shares, which is incorrect.

Moving 'url' option setter to constructor method fixes this issue by assuring that all of pages have different cache tag.